### PR TITLE
Fix update_reg logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ impl<I: AsyncI2c + AsyncErrorType> AsyncTMP451<I, RangeStandard> {
     async(feature = "async", keep_self)
 )]
 impl<I: AsyncI2c + AsyncErrorType> AsyncTMP451<I, RangeExtended> {
-    pub async fn set_standard_range(mut self) -> Result<TMP451<I, RangeStandard>, I::Error> {
+    pub async fn set_standard_range(mut self) -> Result<AsyncTMP451<I, RangeStandard>, I::Error> {
         trace!("set_extended_range");
         self.update_reg(
             Register::ConfigurationRead,
@@ -339,7 +339,7 @@ impl<I: AsyncI2c + AsyncErrorType> AsyncTMP451<I, RangeExtended> {
             0b0000_0100,
         )
         .await?;
-        Ok(TMP451 {
+        Ok(AsyncTMP451 {
             i2c: self.i2c,
             address: self.address,
             range: core::marker::PhantomData::<RangeStandard>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ impl<I: AsyncI2c + AsyncErrorType, R> AsyncTMP451<I, R> {
     ) -> Result<(), I::Error> {
         trace!("update_reg");
         let current = self.read_reg(read_reg.clone()).await?;
-        let updated = current | mask_set & !mask_clear;
+        let updated = (current | mask_set) & !mask_clear;
         if current != updated {
             self.write_reg(write_reg, updated).await?;
         }


### PR DESCRIPTION
This fixes the `update_reg` logic by adding parentheses to enforce the correct order of operations (bitwise AND has greater precedence than bitwise OR, but we want the bitwise OR to occur first).

Depends on #3 