### PR TITLE
Implement embedded-sensors-hal traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ version = "0.3.0"
 defmt = { version = "0.3", optional = true }
 embedded-hal = { version = "1.0", optional = true }
 embedded-hal-async = { version = "1.0", optional = true }
+embedded-sensors-hal = { version = "0.1.0", optional = true }
+embedded-sensors-hal-async = { version = "0.3.0", optional = true }
 log = { version = "0.4", optional = true }
 maybe-async-cfg = "0.2"
 rustversion = "1.0"
@@ -27,6 +29,10 @@ async = ["dep:embedded-hal-async"]
 default = ["sync"]
 defmt-03 = ["dep:defmt"]
 sync = ["dep:embedded-hal"]
+embedded-sensors-hal = ["dep:embedded-sensors-hal", "sync"]
+embedded-sensors-hal-async = ["dep:embedded-sensors-hal-async", "async"]
+embedded-sensors-use-remote = []
+embedded-sensors-use-therm = []
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", default-features = false, features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,11 @@
 pub(crate) mod fmt;
 
 mod error;
+#[cfg(any(
+    feature = "embedded-sensors-hal",
+    feature = "embedded-sensors-hal-async"
+))]
+mod sensor_hal;
 pub use error::{Error, Result};
 
 #[cfg(not(any(feature = "sync", feature = "async")))]

--- a/src/sensor_hal.rs
+++ b/src/sensor_hal.rs
@@ -1,0 +1,152 @@
+#[cfg(feature = "embedded-sensors-hal")]
+use embedded_sensors_hal::{sensor, temperature};
+#[cfg(feature = "embedded-sensors-hal-async")]
+use embedded_sensors_hal_async::{sensor, temperature};
+
+use super::*;
+
+#[cfg(all(
+    feature = "embedded-sensors-hal",
+    feature = "embedded-sensors-hal-async"
+))]
+compile_error!(
+    "Only one of `embedded-sensors-hal` or `embedded-sensors-hal-async` must be enabled at a time."
+);
+
+#[cfg(any(
+    feature = "embedded-sensors-hal",
+    feature = "embedded-sensors-hal-async"
+))]
+impl<E: core::fmt::Debug> sensor::Error for Error<E> {
+    fn kind(&self) -> sensor::ErrorKind {
+        match *self {
+            Error::I2c(_) => sensor::ErrorKind::Peripheral,
+            Error::InvalidValue => sensor::ErrorKind::InvalidInput,
+            _ => sensor::ErrorKind::Other,
+        }
+    }
+}
+
+#[maybe_async_cfg::maybe(
+    sync(
+        feature = "embedded-sensors-hal",
+        self = "TMP451",
+        idents(AsyncI2c(sync = "I2c"), AsyncErrorType(sync = "ErrorType"))
+    ),
+    async(feature = "embedded-sensors-hal-async", keep_self)
+)]
+impl<E: core::fmt::Debug, I: AsyncI2c<Error = E> + AsyncErrorType, R, C> sensor::ErrorType
+    for AsyncTMP451<I, R, C>
+{
+    type Error = Error<E>;
+}
+
+macro_rules! impl_embedded_sensors_hal {
+    ($range:ty, $itype:ty) => {
+        #[maybe_async_cfg::maybe(
+            sync(
+                feature = "embedded-sensors-hal",
+                self = "TMP451",
+                idents(AsyncI2c(sync = "I2c"), AsyncErrorType(sync = "ErrorType"))
+            ),
+            async(feature = "embedded-sensors-hal-async", keep_self)
+        )]
+        impl<E: core::fmt::Debug, I: AsyncI2c<Error = E> + AsyncErrorType, C>
+            temperature::TemperatureSensor for AsyncTMP451<I, $range, C>
+        {
+            async fn temperature(&mut self) -> Result<temperature::DegreesCelsius, I::Error> {
+                #[cfg(feature = "embedded-sensors-use-remote")]
+                {
+                    self.precise_remote_temp().await
+                }
+                #[cfg(not(feature = "embedded-sensors-use-remote"))]
+                {
+                    self.precise_local_temp().await
+                }
+            }
+        }
+
+        #[cfg(feature = "embedded-sensors-hal-async")]
+        impl<E: core::fmt::Debug, I: AsyncI2c<Error = E> + AsyncErrorType, C>
+            temperature::TemperatureThresholdSet for AsyncTMP451<I, $range, C>
+        {
+            async fn set_temperature_threshold_low(
+                &mut self,
+                threshold: temperature::DegreesCelsius,
+            ) -> Result<(), I::Error> {
+                // Low threshold doesn't exist for THERM limits, so return error
+                #[cfg(feature = "embedded-sensors-use-therm")]
+                {
+                    let _ = threshold; // Silence clippy warning
+                    Err(Error::InvalidValue)
+                }
+                #[cfg(all(
+                    not(feature = "embedded-sensors-use-therm"),
+                    feature = "embedded-sensors-use-remote"
+                ))]
+                {
+                    self.set_precise_remote_temp_low_limit(threshold).await
+                }
+                #[cfg(all(
+                    not(feature = "embedded-sensors-use-therm"),
+                    not(feature = "embedded-sensors-use-remote")
+                ))]
+                {
+                    self.set_local_temp_low_limit(threshold as $itype).await
+                }
+            }
+
+            async fn set_temperature_threshold_high(
+                &mut self,
+                threshold: temperature::DegreesCelsius,
+            ) -> Result<(), I::Error> {
+                #[cfg(all(
+                    not(feature = "embedded-sensors-use-remote"),
+                    not(feature = "embedded-sensors-use-therm")
+                ))]
+                {
+                    self.set_local_temp_high_limit(threshold as $itype).await
+                }
+                #[cfg(all(
+                    not(feature = "embedded-sensors-use-remote"),
+                    feature = "embedded-sensors-use-therm"
+                ))]
+                {
+                    self.set_local_temp_therm_limit(threshold as $itype).await
+                }
+                #[cfg(all(
+                    feature = "embedded-sensors-use-remote",
+                    not(feature = "embedded-sensors-use-therm")
+                ))]
+                {
+                    self.set_precise_remote_temp_high_limit(threshold).await
+                }
+                #[cfg(all(
+                    feature = "embedded-sensors-use-remote",
+                    feature = "embedded-sensors-use-therm"
+                ))]
+                {
+                    self.set_remote_temp_therm_limit(threshold as $itype).await
+                }
+            }
+        }
+
+        #[cfg(all(
+            feature = "embedded-sensors-hal-async",
+            feature = "embedded-sensors-use-therm"
+        ))]
+        impl<E: core::fmt::Debug, I: AsyncI2c<Error = E> + AsyncErrorType, C>
+            temperature::TemperatureHysteresis for AsyncTMP451<I, $range, C>
+        {
+            async fn set_temperature_threshold_hysteresis(
+                &mut self,
+                hysteresis: temperature::DegreesCelsius,
+            ) -> Result<(), I::Error> {
+                self.set_hysteresis(hysteresis as u8).await
+            }
+        }
+    };
+}
+
+impl_embedded_sensors_hal!(RangeStandard, u8);
+impl_embedded_sensors_hal!(RangeExtended, i16);


### PR DESCRIPTION
This PR implements [embedded-sensors-hal](https://crates.io/crates/embedded-sensors-hal) for this driver. 

`embedded-sensors-hal` is similar to `embedded-hal` in that it provides a standard, hardware-independent interface, but of course this focuses on sensors. This allows others to create standalone abstractions that involve temperature sensing. An example would be creating an abstract PID controller algorithm for controlling a fan based on temperature, which can make use of any temperature sensor driver that implements this HAL.

This implementation sits on top of the underlying TMP451 implementation details and is feature-gated, thus imposes no changes or penalties for those who do not wish to use the abstraction.
